### PR TITLE
fix: BookController의 createBook에서 회원 고유id를 bookDto에 넣음

### DIFF
--- a/src/main/java/com/spring/sorigalpi/controller/BookController.java
+++ b/src/main/java/com/spring/sorigalpi/controller/BookController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.spring.sorigalpi.auth.PrincipalDetails;
 import com.spring.sorigalpi.dto.BookDTO;
 import com.spring.sorigalpi.entity.Book;
 import com.spring.sorigalpi.service.BookService;
@@ -62,7 +64,8 @@ public class BookController {
 			notes = "화책 테이블 정보 생성 API") 
 	@ApiResponse(code = 200, message = "성공")
 	@PostMapping("/createBook") //동화책 생성
-	public ResponseEntity<BasicResponse> createBook(@RequestBody BookDTO bookDTO){
+	public ResponseEntity<BasicResponse> createBook(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody BookDTO bookDTO) {
+		bookDTO.setMemberId(principalDetails.getMember().getMemberId());
 		String bookId = bookService.createBook(bookDTO);
 		
 		BasicResponse basicResponse =  BasicResponse.builder()

--- a/src/main/java/com/spring/sorigalpi/service/MemberService.java
+++ b/src/main/java/com/spring/sorigalpi/service/MemberService.java
@@ -69,9 +69,9 @@ public class MemberService extends Base {
 	}
 
 	@Transactional
-	public String updateMember(String memberId, MemberDto memberDto) { // 사용자 정보 변경 메소드
+	public String updateMember(MemberDto memberDto) { // 사용자 정보 변경 메소드
 		// findById 메소드를 통해 값을 가져오면서 해당 값은 영속성을 가진다.
-		Member member = memberRepository.findById(memberId)
+		Member member = memberRepository.findById(memberDto.getMemberId())
 				.orElseThrow(() -> new BaseException(ErrorCode.MEMBER_NOT_FOUND));
 
 		// 변경할 비밀번호 암호화하여 저장


### PR DESCRIPTION
프론트에서 동화책 CRUD 연결 중입니다.
createBook메소드 테스트 중에 에러 나는 것을 확인했습니다.
 /book/createBook으로 POST 요청했으며, 요청 파라미터는 다음과 같았습니다.

{
  bookName: "책이름",
  info: "책설명",
  status: "공개",
  recordable: "yes"
}

현재 Controller가 이 요청 파라미터를 그대로 DB에 넣고 있습니다.
이대로 넣으면 필수값인 회원고유id가 null이기 때문에 에러가 납니다.
프론트에선 현재 회원의 회원고유id를 알 방법이 현재로선 없습니다.
백 쪽에서 스프링시큐리티의 기능을 이용해 Controller에서 추가해줬으면 합니다.
예시로 createBook을 수정해뒀습니다. 앞으로 회원id가 필요한 기능은 백에서 이렇게 처리해줬으면 합니다.

그리고 동화책 저장 페이지에 녹음 공개할지 말지 여부를 체크하도록 되어 있는데 아직 녹음 테이블에 접근할 수 있는 Service가 백엔드에 없으니 일단 내버려둡니다.